### PR TITLE
vfucopy.h:fix potential out-of-bounds

### DIFF
--- a/vfucopy.h
+++ b/vfucopy.h
@@ -22,9 +22,9 @@
 
 /* clipboard modes *********************************************************/
 
-#define CLIPBOARD_COPY      1
-#define CLIPBOARD_MOVE      2
-#define CLIPBOARD_SYMLINK   3
+#define CLIPBOARD_COPY      0
+#define CLIPBOARD_MOVE      1
+#define CLIPBOARD_SYMLINK   2
 
 /* overwrite modes *********************************************************/
 


### PR DESCRIPTION
I'm not sure if this would break anything, but the intent for this patch
is to fix the potential array out-of-bounds at L1183 of vfucopy.cpp
(CB_DESC could receive a subscript of "3")